### PR TITLE
Several fixes

### DIFF
--- a/src/main/java/org/terracotta/tinypounder/ProcUtils.java
+++ b/src/main/java/org/terracotta/tinypounder/ProcUtils.java
@@ -23,7 +23,7 @@ public class ProcUtils {
       @Override
       public void write(int b) throws IOException {
         buffer.write(b);
-        if (((byte) b) == ((byte) 10)) {
+        if (((byte) b) == ((byte) 10)) { // \n
           String newLine = new String(buffer.toByteArray(), StandardCharsets.UTF_8);
           while (!consoleLines.offer(newLine)) {
             consoleLines.poll();
@@ -35,9 +35,9 @@ public class ProcUtils {
     };
 
     consoleLines.clear();
-    consoleLines.offer("Running:");
-    consoleLines.offer(command);
-    consoleLines.offer("...");
+    consoleLines.offer("Running:\n");
+    consoleLines.offer(command + "\n");
+    consoleLines.offer("...\n");
 
     AnyProcess process = AnyProcess.newBuilder()
         .command(ProcUtils.isWindows() ? new String[]{"cmd.exe", "/c", command} : new String[]{"/bin/bash", "-c", command})

--- a/src/main/java/org/terracotta/tinypounder/RunningServer.java
+++ b/src/main/java/org/terracotta/tinypounder/RunningServer.java
@@ -77,7 +77,7 @@ class RunningServer {
   }
 
   void refreshConsole() {
-    String text = String.join("\n", lines);
+    String text = String.join("", lines);
     console.setValue(text);
     console.setCursorPosition(text.length());
   }

--- a/src/main/java/org/terracotta/tinypounder/Settings.java
+++ b/src/main/java/org/terracotta/tinypounder/Settings.java
@@ -1,0 +1,190 @@
+package org.terracotta.tinypounder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
+/**
+ * @author Mathieu Carbou
+ */
+@Service
+public class Settings {
+
+  @Value("${kitPath}")
+  private String kitPath;
+
+  @Value("${licensePath}")
+  private String licensePath;
+
+  @Value("${offheapCount}")
+  private int offheapCount;
+
+  @Value("${dataRootCount}")
+  private int dataRootCount;
+
+  @Value("${serverCount}")
+  private int serverCount;
+
+  @Value("${stripeCount}")
+  private int stripeCount;
+
+  @Value("${reconnectWindow}")
+  private int reconnectWindow;
+
+  private final File config = new File(System.getProperty("user.home"), ".tinypounder/config.properties");
+
+  @PostConstruct
+  public void load() {
+    config.getParentFile().mkdirs();
+    Properties properties = new Properties();
+    if (config.exists()) {
+      try (InputStreamReader reader = new InputStreamReader(new FileInputStream(config), "UTF-8")) {
+        properties.load(reader);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+    // always prefer system props over saved config
+    if (kitPath == null || kitPath.isEmpty()) {
+      kitPath = properties.getProperty("kitPath");
+      File folder = new File(kitPath);
+      if (!folder.exists() || !folder.isDirectory()) {
+        kitPath = null;
+      }
+    }
+    if (licensePath == null || licensePath.isEmpty()) {
+      licensePath = properties.getProperty("licensePath");
+      File file = new File(licensePath);
+      if (!file.exists() || !file.isFile()) {
+        licensePath = null;
+      }
+    }
+    if (offheapCount < 1) {
+      offheapCount = Integer.parseInt(properties.getProperty("offheapCount", "0"));
+      if (offheapCount < 1) {
+        offheapCount = 2;
+      }
+    }
+    if (dataRootCount < 1) {
+      dataRootCount = Integer.parseInt(properties.getProperty("dataRootCount", "0"));
+      if (dataRootCount < 1) {
+        dataRootCount = 2;
+      }
+    }
+    if (serverCount < 1) {
+      serverCount = Integer.parseInt(properties.getProperty("serverCount", "0"));
+      if (serverCount < 1) {
+        serverCount = 2;
+      }
+    }
+    if (stripeCount < 1) {
+      stripeCount = Integer.parseInt(properties.getProperty("stripeCount", "0"));
+      if (stripeCount < 1) {
+        stripeCount = 2;
+      }
+    }
+    if (reconnectWindow < 5) {
+      reconnectWindow = Integer.parseInt(properties.getProperty("reconnectWindow", "0"));
+      if (reconnectWindow < 5) {
+        reconnectWindow = 120;
+      }
+    }
+  }
+
+  @PreDestroy
+  public void save() {
+    Properties properties = new Properties();
+    if (kitPath != null) {
+      properties.setProperty("kitPath", kitPath);
+    }
+    if (licensePath != null) {
+      properties.setProperty("licensePath", licensePath);
+    }
+    if (offheapCount >= 1) {
+      properties.setProperty("offheapCount", String.valueOf(offheapCount));
+    }
+    if (dataRootCount >= 1) {
+      properties.setProperty("dataRootCount", String.valueOf(dataRootCount));
+    }
+    if (serverCount >= 1) {
+      properties.setProperty("serverCount", String.valueOf(serverCount));
+    }
+    if (stripeCount >= 1) {
+      properties.setProperty("stripeCount", String.valueOf(stripeCount));
+    }
+    if (reconnectWindow >= 5) {
+      properties.setProperty("reconnectWindow", String.valueOf(reconnectWindow));
+    }
+    try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(config), "UTF-8")) {
+      properties.store(writer, "AUTO-GENERATED FILE");
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public String getKitPath() {
+    return kitPath;
+  }
+
+  public void setKitPath(String kitPath) {
+    this.kitPath = kitPath;
+  }
+
+  public String getLicensePath() {
+    return licensePath;
+  }
+
+  public void setLicensePath(String licensePath) {
+    this.licensePath = licensePath;
+  }
+
+  public int getOffheapCount() {
+    return offheapCount;
+  }
+
+  public int getDataRootCount() {
+    return dataRootCount;
+  }
+
+  public int getServerCount() {
+    return serverCount;
+  }
+
+  public int getStripeCount() {
+    return stripeCount;
+  }
+
+  public void setOffheapCount(int offheapCount) {
+    this.offheapCount = offheapCount;
+  }
+
+  public void setDataRootCount(int dataRootCount) {
+    this.dataRootCount = dataRootCount;
+  }
+
+  public void setStripeCount(int stripeCount) {
+    this.stripeCount = stripeCount;
+  }
+
+  public void setServerCount(int serverCount) {
+    this.serverCount = serverCount;
+  }
+
+  public int getReconnectWindow() {
+    return reconnectWindow;
+  }
+
+  public void setReconnectWindow(int reconnectWindow) {
+    this.reconnectWindow = reconnectWindow;
+  }
+}

--- a/src/main/java/org/terracotta/tinypounder/TinypounderApplication.java
+++ b/src/main/java/org/terracotta/tinypounder/TinypounderApplication.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.tinypounder;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -28,24 +27,8 @@ import java.util.concurrent.ScheduledExecutorService;
 @Configuration
 public class TinypounderApplication {
 
-  @Value("${kitPath}")
-  private String kitPath;
-
   public static void main(String[] args) throws Exception {
     SpringApplication.run(TinypounderApplication.class, args);
-  }
-
-  @Bean
-  public KitAwareClassLoaderDelegator initializeKitAwareClassLoader() {
-    KitAwareClassLoaderDelegator kitAwareClassLoaderDelegator = new KitAwareClassLoaderDelegator();
-    if (kitPath != null && kitPath.length() > 0) {
-      try {
-        kitAwareClassLoaderDelegator.setKitPathAndUpdate(kitPath);
-      } catch (Exception e) {
-        new RuntimeException("Please make sure the kitPath is properly set, current value is : " + kitPath, e);
-      }
-    }
-    return kitAwareClassLoaderDelegator;
   }
 
   @Bean(destroyMethod = "shutdownNow")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,11 @@
 kitPath=
 licensePath=
+# loaded by Settings. Keep it to 0.
+offheapCount=0
+dataRootCount=0
+serverCount=0
+stripeCount=0
+reconnectWindow=0
 # locally set sysprops to true to your launcher in dev mode
 spring.devtools.livereload.enabled=false
 spring.devtools.restart.enabled=false


### PR DESCRIPTION
- no need to use system props anymore: kit path, license path, #stripe, #server, #offheaps, #dataroots, reconnect window are all backup into ${user.home}/.tinypounder/config.properties
- fixing the duplicate EOL in teh console
- fixing mainConsole not focusing at the end of a command